### PR TITLE
Update z-index to the maximum value possible

### DIFF
--- a/src/entrypoints/background.ts
+++ b/src/entrypoints/background.ts
@@ -70,7 +70,7 @@ export default defineBackground(() => {
                         width: 100vw;
                         height: 100vh;
                         pointer-events: none;
-                        z-index: 100000;
+                        z-index: 2147483647;
                         backdrop-filter: grayscale(${intensity}%);
                       `;
                         document.documentElement.appendChild(overlay);
@@ -324,7 +324,7 @@ export default defineBackground(() => {
                         width: 100vw;
                         height: 100vh;
                         pointer-events: none;
-                        z-index: 100000;
+                        z-index: 2147483647;
                         backdrop-filter: grayscale(${intensity}%);
                       `;
                       document.documentElement.appendChild(overlay);

--- a/src/entrypoints/content.ts
+++ b/src/entrypoints/content.ts
@@ -27,7 +27,7 @@ const updateOverlay = (show: boolean, intensity: number = 100) => {
         width: 100vw;
         height: 100vh;
         pointer-events: none;
-        z-index: 100000;
+        z-index: 2147483647;
         backdrop-filter: grayscale(${intensity}%);
       `;
       document.documentElement.appendChild(overlayElement);


### PR DESCRIPTION
**This pull request updates the z-index position to 2147483647 of `div` with the id `monochromate-overlay` which is the maximum value possible for browsers.**

This change prevents any appearing popups with a z-index value greater than 100000 (the orginal value) the overlay.

Before the changes:
<img width="400" height="300" alt="Screenshot 2025-08-03 173903" src="https://github.com/user-attachments/assets/85755d0f-c7e9-428e-8bef-f4e66b96b31c" />


After with the changes:
<img width="400" height="300" alt="Screenshot 2025-08-03 181934" src="https://github.com/user-attachments/assets/0cce50f2-fba4-4da5-a856-18e494450039" />

**Sources and references:**
https://www.digitalocean.com/community/tutorials/css-z-index
https://stackoverflow.com/questions/491052/minimum-and-maximum-value-of-z-index/25461690#25461690
